### PR TITLE
reset millisecond part for all dates

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ export default function parse (parse, from) {
 
   const text = String(parse).toLowerCase()
   const date = new Date((isFinite(from) && text.indexOf('now') === -1) ? Number(from) : Date.now())
+  date.setMilliseconds(0)
   const [, year = 'y', month = 'm', day = 'd'] = text.match(YMD) || []
   const [, hour = 'h', minute = 'm', second = 's'] = text.match(HMS) || []
   let match = {year, month, day, hour, minute, second}

--- a/index.js
+++ b/index.js
@@ -8,11 +8,11 @@ export default function parse (parse, from) {
 
   const text = String(parse).toLowerCase()
   const date = new Date((isFinite(from) && text.indexOf('now') === -1) ? Number(from) : Date.now())
-  date.setMilliseconds(0)
   const [, year = 'y', month = 'm', day = 'd'] = text.match(YMD) || []
   const [, hour = 'h', minute = 'm', second = 's'] = text.match(HMS) || []
   let match = {year, month, day, hour, minute, second}
-
+  
+  date.setMilliseconds(0)
   Object.keys(match).forEach((unit) => {
     const move = unit === 'month' ? 1 : 0 // Month have zero based index
     const prev = `${date[`get${DATE[unit]}`]() + move}` // Shift to consistent index


### PR DESCRIPTION
When creating a Date object with parse such as `parse('07:00:00')` it would be nice if the millisecond part of that time object is 0. For instance that makes it easier to use for comparison.